### PR TITLE
feat: add a scroll to top wrapper component

### DIFF
--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect, ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
+
+function ScrollToTop({ children }: { children: ReactNode }) {
+  const location = useLocation();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location]);
+
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{children}</>;
+}
+
+export default ScrollToTop;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import reducer, { initialState } from './store/reducer';
 import { StateProvider } from './components/StateProvider';
+import ScrollToTop from './components/ScrollToTop';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
@@ -14,7 +15,9 @@ root.render(
   <React.StrictMode>
     <BrowserRouter>
       <StateProvider initialState={initialState} reducer={reducer}>
-        <App />
+        <ScrollToTop>
+          <App />
+        </ScrollToTop>
       </StateProvider>
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
When routes between pages, we want the auto-scroll top as the default behavior. Create a wrapper component to wrap the whole app.